### PR TITLE
ReadmeChangeLinkUrl(fix): Fix link due to new name of repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NexusZiaApi
 ![CPP](https://img.shields.io/badge/C++-11-blue.svg)
-[![Build Status](https://travis-ci.org/Nexus-Software/cpp_zia_api.svg?branch=master)](https://travis-ci.org/Nexus-Software/cpp_zia_api)
-[![Build Status](https://ci.appveyor.com/api/projects/status/so486m5mk5ih11ji/branch/master?svg=true)](https://ci.appveyor.com/project/Engue0774/cpp-zia-api/branch/master)
-[![GitHub Issues](https://img.shields.io/github/issues/Nexus-Software/cpp_zia_api.svg)](https://github.com/Nexus-Software/cpp_zia_api/issues)
-[![GitHub Pull Request](https://img.shields.io/github/issues-pr/Nexus-Software/cpp_zia_api.svg)](https://github.com/Nexus-Software/cpp_zia_api/issues)
+[![Build Status](https://travis-ci.org/Nexus-Software/NexusZiaApi.svg?branch=master)](https://travis-ci.org/Nexus-Software/NexusZiaApi)
+[![Build status](https://ci.appveyor.com/api/projects/status/493qgqfqck1iqeyx/branch/master?svg=true)](https://ci.appveyor.com/project/aenguerrand/nexusziaapi/branch/master)
+[![GitHub Issues](https://img.shields.io/github/issues/Nexus-Software/NexusZiaApi.svg)](https://github.com/Nexus-Software/NexusZiaApi/issues)
+[![GitHub Pull Request](https://img.shields.io/github/issues-pr/Nexus-Software/NexusZiaApi.svg)](https://github.com/Nexus-Software/NexusZiaApi/issues)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 Welcome to the Github project of Zia API by Nexus-Software.


### PR DESCRIPTION
# ReadmeChangeLinkUrl [FIX]
BY @aenguerrand
## Purpose
Fix link into Readme because name of repository change
